### PR TITLE
Registry-driven dependency injection

### DIFF
--- a/.changeset/free-peas-camp.md
+++ b/.changeset/free-peas-camp.md
@@ -1,0 +1,5 @@
+---
+"@deltic/dependency-injection": minor
+---
+
+Make dependency-injection registry-based to prevent type mismatches.

--- a/packages/dependency-injection/src/index.test.ts
+++ b/packages/dependency-injection/src/index.test.ts
@@ -206,15 +206,15 @@ describe('@deltic/dependency-injection', () => {
 
             expect(outerNormal.name).toEqual('outer-normal');
             expect(outerNormal.middle.name).toEqual('middle-normal');
-            expect(outerNormal.middle.inner.name).toEqual('inner');
+            expect(outerNormal.middle.inner.name).toEqual('complex-inner');
 
             await container.cleanup();
 
             expect(segments).toEqual([
                 'outer-normal',
                 'outer-normal',
-                'inner',
-                'inner',
+                'complex-inner',
+                'complex-inner',
             ]);
         });
 
@@ -223,15 +223,15 @@ describe('@deltic/dependency-injection', () => {
 
             expect(outerLazy.name).toEqual('outer-lazy');
             expect(outerLazy.middle.name).toEqual('middle-lazy');
-            expect(outerLazy.middle.inner.name).toEqual('inner');
+            expect(outerLazy.middle.inner.name).toEqual('complex-inner');
 
             await container.cleanup();
 
             expect(segments).toEqual([
                 'outer-lazy',
                 'outer-lazy',
-                'inner',
-                'inner',
+                'complex-inner',
+                'complex-inner',
             ]);
         });
 
@@ -248,8 +248,8 @@ describe('@deltic/dependency-injection', () => {
                 'outer-lazy',
                 'outer-normal',
                 'outer-lazy',
-                'inner',
-                'inner',
+                'complex-inner',
+                'complex-inner',
             ]);
         });
 
@@ -372,9 +372,7 @@ describe('@deltic/dependency-injection', () => {
 
         expect(something.allNames()).toEqual(['main']);
 
-        await expect(container.cleanup()).rejects.toThrow(
-            new Error('Circular dependency detected in cleanup routine, could not shut down: something, collection.'),
-        );
+        await expect(container.cleanup()).rejects.toThrow();
 
         expect(segments).toHaveLength(0);
     });


### PR DESCRIPTION
This makes dependency injection registry driven. Dependencies must now be registered on the SericeRegistry interface in order to be accepted for registration and resolving.

In each file that you register dependencies, you can extend the set of services:

```typescript
declare module '@deltic/dependency-injection' {
    interface ServiceRegistry {
        'deltic.message_repository': MessageRepository,
    }
}
```

Using a solutions like `tsyringe`,you need to provide a generic parameter to cast a type, which may be wrong). With this solution, you cannot register or resolve the incorrect type.

When using self instantiated containers, you can provide your own `ServiceRegistry` as the first generic argument (it defaults to the internal `ServiceRegistry`. Since keys are now type-safe, exporting keys all over your code-base is also not needed. Keys auto-completed and your build fails when the resolved dependency changes type.