### PR TITLE
Implement type-safety through service keys.

### DIFF
--- a/packages/dependency-injection/src/index.ts
+++ b/packages/dependency-injection/src/index.ts
@@ -47,6 +47,10 @@ class DependencyContainer {
     private resolutionStack = new Set<string>();
 
     register<Service, const Key extends string = string>(key: Key, definition: ServiceDefinition<Service>): ServiceKey<Service> {
+        if (this.definitions[key] !== undefined) {
+            throw new Error(`Dependency ${key} is already registered`);
+        }
+
         if (definition.lazy) {
             const proxy = this.createProxyFor(key as unknown as ServiceKey<Service & object>, definition as ServiceDefinition<Service & object>);
             definition.factory = () => proxy;
@@ -147,6 +151,10 @@ class DependencyContainer {
     }
 
     registerInstance<Service extends object>(key: string, definition: InstanceDefinition<Service>): ServiceKey<Service> {
+        if (this.definitions[key] !== undefined) {
+            throw new Error(`Dependency ${key} is already registered`);
+        }
+
         const {cleanup, instance} = definition;
         this.cache[key] = instance;
         this.definitions[key] = {
@@ -273,6 +281,15 @@ class DependencyContainer {
 
         return instance;
     }
+}
+
+/**
+ * Create service keys without registering a service. Only use this to work around the
+ * intentional limitation of only receiving a token when a service is registered. This
+ * is an escape-hatch, proceed with caution.
+ */
+export function dangerouslyForgeServiceKey<Service>(key: string): ServiceKey<Service> {
+    return key as unknown as ServiceKey<Service>;
 }
 
 export default DependencyContainer;

--- a/packages/dependency-injection/src/index.ts
+++ b/packages/dependency-injection/src/index.ts
@@ -30,7 +30,13 @@ interface ResolvedService {
     instance: any,
 }
 
-export class DependencyContainer {
+declare const service: unique symbol;
+
+export type ServiceKey<Service> = string & {
+    [service]: Service,
+}
+
+class DependencyContainer {
     private cache: Record<string, any> = {};
     private definitions: Record<string, ServiceDefinition> = {};
 
@@ -40,13 +46,15 @@ export class DependencyContainer {
     // Stack to track current resolution chain
     private resolutionStack = new Set<string>();
 
-    register<Service>(key: string, definition: ServiceDefinition<Service>): void {
+    register<Service, const Key extends string = string>(key: Key, definition: ServiceDefinition<Service>): ServiceKey<Service> {
         if (definition.lazy) {
-            const proxy = this.createProxyFor(key, definition as ServiceDefinition<Service & object>);
+            const proxy = this.createProxyFor(key as unknown as ServiceKey<Service & object>, definition as ServiceDefinition<Service & object>);
             definition.factory = () => proxy;
         }
 
         this.definitions[key] = definition;
+
+        return key as unknown as ServiceKey<Service>;
     }
 
     async cleanup(): Promise<void> {
@@ -138,7 +146,7 @@ export class DependencyContainer {
         }
     }
 
-    registerInstance<Service extends object>(key: string, definition: InstanceDefinition<Service>): void {
+    registerInstance<Service extends object>(key: string, definition: InstanceDefinition<Service>): ServiceKey<Service> {
         const {cleanup, instance} = definition;
         this.cache[key] = instance;
         this.definitions[key] = {
@@ -154,9 +162,11 @@ export class DependencyContainer {
                 instance,
             });
         }
+
+        return key as unknown as ServiceKey<Service>;
     }
 
-    private createProxyFor<Service extends object>(key: string, definition: ServiceDefinition<Service>): Service {
+    private createProxyFor<Service extends object>(key: ServiceKey<Service>, definition: ServiceDefinition<Service>): Service {
         const {factory, cache = true, cleanup} = definition;
         const resolveInstance = () => {
             const cached = this.cache[key];
@@ -199,7 +209,7 @@ export class DependencyContainer {
         return new Proxy<Service>({} as Service, handlers);
     }
 
-    resolveLazy<Service extends object>(key: string): Service {
+    resolveLazy<Service extends object>(key: ServiceKey<Service>): Service {
         const definition = this.definitions[key];
 
         if (!definition) {
@@ -211,7 +221,7 @@ export class DependencyContainer {
         return this.createProxyFor(key, definition);
     }
 
-    resolve<Service extends object>(key: string): Service {
+    resolve<const Service extends object>(key: ServiceKey<Service>): Service {
         if (this.resolutionStack.has(key)) {
             return this.resolveLazy<Service>(key);
         }
@@ -264,6 +274,8 @@ export class DependencyContainer {
         return instance;
     }
 }
+
+export default DependencyContainer;
 
 export const container = new DependencyContainer();
 


### PR DESCRIPTION
As an alternative to #3, this PR adds service keys to the dependency injection package. Service keys are returned when you register a service and used to resolve a service. Service keys embed the type of service that will be returned, this prevents from having to re-declare which type of service you're resolving.

```typescript
import type {Pool} from 'pg';

const PG_POOL = container.register<Pool>('database', {
    lazy: true,
    factory: () => createDatabaseClass(),
});

const pool = container.resolve(PG_POOL);
// ^ this is now resolved as the Pool type from the pg package.